### PR TITLE
feat(compress): add option to specify compression quality

### DIFF
--- a/lib/commands/compress.js
+++ b/lib/commands/compress.js
@@ -25,6 +25,11 @@ exports.builder = (yargs) => {
       alias: ['v'],
       describe: 'Display verbose output',
       type: 'boolean',
+    })
+    .option('quality', {
+      alias: ['q'],
+      describe: 'Compression quality (0-11)',
+      type: 'number',
     });
 };
 
@@ -41,14 +46,29 @@ exports.handler = (argv) => {
         logger.warn(`could not find file ${filePath}`);
         return;
       }
+
       fs.readFile(filePath, (readFileErr, fileBuffer) => {
-        const compressedFileBuffer = brotli.compress(fileBuffer);
+        let compressionQuality = 11;
+        if (typeof argv.quality === 'number') {
+          if (argv.quality < 0 || argv.quality > 11) {
+            logger.warn('Unexpected compression quality provided, defaulting to 11');
+          } else {
+            compressionQuality = argv.quality;
+          }
+        }
+
+        const compressedFileBuffer = brotli.compress(fileBuffer, {
+          quality: compressionQuality,
+        });
+
         if (compressedFileBuffer === null) {
           logger.warn(`${filePath} could not be compressed`);
           return;
         }
+
         const outdir = argv.outdir ? argv.outdir : path.dirname(filePath);
         const outFilePath = path.join(outdir, `${path.basename(filePath)}.br`);
+
         fs.writeFile(outFilePath, compressedFileBuffer, (writeFileErr) => {
           if (writeFileErr) {
             logger.error(`an error occurred while writing to ${outFilePath}. ${writeFileErr}`);

--- a/test/commands/compress.spec.js
+++ b/test/commands/compress.spec.js
@@ -22,7 +22,7 @@ describe('compress', () => {
 
   describe('#builder()', () => {
     it('should set up options', () => {
-      const expectedOptions = ['outdir', 'verbose'];
+      const expectedOptions = ['outdir', 'verbose', 'quality'];
       const optionSpy = sandbox.stub();
       optionSpy.callsFake(() => ({ option: optionSpy }));
       const mockYargs = { option: optionSpy };
@@ -30,7 +30,7 @@ describe('compress', () => {
       compressCmd.builder(mockYargs);
 
       expectedOptions.forEach(o => optionSpy.calledWith(o));
-      assert.equal(optionSpy.callCount, expectedOptions.length, 'Did not setup expected number of options');
+      assert.equal(optionSpy.callCount, expectedOptions.length, 'did not setup expected number of options');
     });
   });
 


### PR DESCRIPTION
Add option to specify compresion level/quality (--quality or -q). Quality can range from 0 to 11 (inclusive).

Resolves #11.